### PR TITLE
Fix incorrect ownership of algorithms in processing provider. Fixes #11

### DIFF
--- a/land_survey_provider.py
+++ b/land_survey_provider.py
@@ -38,9 +38,6 @@ class landsurveyProvider(QgsProcessingProvider):
     def __init__(self):
         QgsProcessingProvider.__init__(self)
 
-        # Load algorithms
-        self.alglist = [landsurveyAlgorithm()]
-
     def unload(self):
         """
         Unloads the provider. Any tear-down steps required by the provider
@@ -52,8 +49,7 @@ class landsurveyProvider(QgsProcessingProvider):
         """
         Loads all algorithms belonging to this provider.
         """
-        for alg in self.alglist:
-            self.addAlgorithm( alg )
+        self.addAlgorithm( landsurveyAlgorithm() )
 
     def id(self):
         """


### PR DESCRIPTION
"Since a provider transfers ownership of an algorithm instance when it calls addAlgorithm, it's not safe to keep a reference to these instances and reuse them.

Fixes "wrapped C/C++ object of type BufferByFixedPercentage has been deleted" error when editing processing options with the plugin installed."

Thanks to nyall

Same problem on other plugins. https://github.com/jdugge/BufferByPercentage/pull/14
